### PR TITLE
Fix link for rroonga on en doc

### DIFF
--- a/users/index.html
+++ b/users/index.html
@@ -9,6 +9,6 @@ title: Users
 <section id="buzztter">
   <h2>buzztter</h2>
   <p><a href="http://buzztter.com/">buzztter - Snapshoot the tweets!</a></p>
-  <p>It uses groonga + <a href="http://groonga.rubyforge.org/index.html.ja#about-rroonga">rroonga</a> combination for index update. It also uses groonga + <a href="http://nroonga.github.com/">nroonga</a> combination for fulltext search.</p>
+  <p>It uses groonga + <a href="http://groonga.rubyforge.org/#about-rroonga">rroonga</a> combination for index update. It also uses groonga + <a href="http://nroonga.github.com/">nroonga</a> combination for fulltext search.</p>
   <p>It's a Web service that shows buzz-phrase on Twitter. It uses groonga for fulltext search.</p>
 </section>


### PR DESCRIPTION
英語のドキュメント中の rroonga へのリンクが ja へのリンクになっていたので、en へのリンクに修正しました。
