### PR TITLE
Fix wrong link in ja/users/index.html

### DIFF
--- a/ja/users/index.html
+++ b/ja/users/index.html
@@ -3,7 +3,7 @@ layout: ja
 title: 利用者のみなさん
 ---
 <div class="note">
-  <p><em>もっとgroongaを広めるために、みなさんの事例をたくさん紹介したいと思っています！事例のある方はgroonga at razil.jpにメールするか、<a href="https://github.com/groonga/groonga.github.com">GitHub</a>でpull requestを送ってください！</em></p>
+  <p><em>もっとgroongaを広めるために、みなさんの事例をたくさん紹介したいと思っています！事例のある方はgroonga at razil.jpにメールするか、<a href="https://github.com/groonga/groonga.org">GitHub</a>でpull requestを送ってください！</em></p>
   <p>みなさんのサイトで<a href="../logo/">groongaのロゴ</a>を使ってください！</p>
   <p>みなさんのノートパソコンに<a href="../sticker/">groongaのステッカー</a>を貼ってください！</p>
 </div>


### PR DESCRIPTION
利用事例報告先のリポジトリ名が古いままだったのでご報告します。

```
https://github.com/groonga/groonga.github.com ->
https://github.com/groonga/groonga.org
```

他にもgroonga.github.comのままになっている箇所があったのですが、
修正してよいでしょうか？（svgファイルは修正不要かと思いますが）

```
% grep -l -i "groonga.github.com" **/*
docs/contribution/development/release.html
docs/searchindex.js
docs/sources/contribution/development/release.txt
images/characteristic.svg
images/groonga-related-projects-bindings.svg
images/groonga-related-projects-databases.svg
images/groonga-related-projects-libraries.svg
images/groonga-related-projects-utilities.svg
images/groonga-related-projects.svg
images/header-background.svg
images/install.svg
ja/docs/contribution/development/release.html
ja/docs/sources/contribution/development/release.txt
users/index.html
```
