### PR TITLE
Fix wrong link in users/index.html

### DIFF
--- a/users/index.html
+++ b/users/index.html
@@ -3,7 +3,7 @@ layout: en
 title: Users
 ---
 <div class="note">
-  <p><em>Please send a mail to groonga at razil.jp or send a pull request on <a href="https://github.com/groonga/groonga.github.com">GitHub</a> if you are a groonga user! We want to add you to spread groonga!</em></p>
+  <p><em>Please send a mail to groonga at razil.jp or send a pull request on <a href="https://github.com/groonga/groonga.org">GitHub</a> if you are a groonga user! We want to add you to spread groonga!</em></p>
   <p>Please also consider about using <a href="../logo/">groonga logos</a> on your site!</p>
   <p>Please also consider about sticking <a href="../sticker/">groonga stickers</a> on your note PC!</p>
 </div>


### PR DESCRIPTION
docsに含まれない英語版ページのリンクを修正しました。

https://github.com/groonga/groonga.github.com ->
https://github.com/groonga/groonga.org
