### PR TITLE
use "Groonga" notation to ja/related-projects.html.

### DIFF
--- a/ja/related-projects.html
+++ b/ja/related-projects.html
@@ -3,8 +3,8 @@ layout: ja
 title: 関連プロジェクト
 ---
 <section id="related_projects">
-  <h2>groonga関連プロジェクト</h2>
-  <p>groonga関連プロジェクトは以下のような4つのカテゴリに分けられます。</p>
+  <h2>Groonga関連プロジェクト</h2>
+  <p>Groonga関連プロジェクトは以下のような4つのカテゴリに分けられます。</p>
   <ul>
     <li><a href="#databases">データベース</a></li>
     <li><a href="#bindings">言語バインディング</a></li>
@@ -15,17 +15,17 @@ title: 関連プロジェクト
 
   <section id="databases">
     <h3>データベース</h3>
-    <p>groongaを他のデータベース製品と組合せて使うこともできます。拡張したSQLクエリを使うことができます。</p>
+    <p>Groongaを他のデータベース製品と組合せて使うこともできます。拡張したSQLクエリを使うことができます。</p>
     <figure>
       <img src="/images/groonga-related-projects-databases.png" />
     </figure>
     <section id="mroonga">
-      <h4>groonga + MySQL</h4>
-      <p><a href="http://mroonga.org/">mroonga</a>はgroongaを用いたMySQLのストレージエンジンです。mroongaを用いることにより、MySQLでも高速で高精度な全文検索機能を利用できます。</p>
+      <h4>Groonga + MySQL</h4>
+      <p><a href="http://mroonga.org/">Mroonga</a>はGroongaを用いたMySQLのストレージエンジンです。Mroongaを用いることにより、MySQLでも高速で高精度な全文検索機能を利用できます。</p>
     </section>
     <section id="textsearch_groonga">
       <h4>groonga + PostgreSQL</h4>
-      <p><a href="http://textsearch-ja.projects.postgresql.org/textsearch_groonga.html">textsearch_groonga</a>はgroongaを用いた全文検索機能をPostgreSQLに追加します。</p>
+      <p><a href="http://textsearch-ja.projects.postgresql.org/textsearch_groonga.html">textsearch_groonga</a>はGroongaを用いた全文検索機能をPostgreSQLに追加します。</p>
     </section>
   </section>
 
@@ -39,47 +39,47 @@ title: 関連プロジェクト
                 Joyent Node.js open source or commercial project." />
     </figure>
     <section id="nroonga">
-      <h4>groonga + Node.js （バインディング）</h4>
-      <p><a href="http://nroonga.github.com/">nroonga</a>はNode.js用のgroongaバインディングです。nroongaはgroongaをライブラリとして使うので、全文検索はNode.jsプロセスが行います。</p>
+      <h4>Groonga + Node.js （バインディング）</h4>
+      <p><a href="http://nroonga.github.com/">nroonga</a>はNode.js用のGroongaバインディングです。NroongaはGroongaをライブラリとして使うので、全文検索はNode.jsプロセスが行います。</p>
     </section>
     <section id="rroonga">
-      <h4>groonga + Ruby</h4>
-      <p><a href="http://groonga.rubyforge.org/#about-rroonga">rroonga</a>はgroongaのRubyバインディングです。
-        rroongaはgroongaの全文検索システムを提供している<a href="http://groonga.rubyforge.org/index.html.ja">ラングバプロジェクト</a>の一部です。</p>
+      <h4>Groonga + Ruby</h4>
+      <p><a href="http://groonga.rubyforge.org/#about-rroonga">Rroonga</a>はGroongaのRubyバインディングです。
+        RroongaはGroongaの全文検索システムを提供している<a href="http://groonga.rubyforge.org/index.html.ja">ラングバプロジェクト</a>の一部です。</p>
     </section>
     <section id="p5-groonga">
-      <h4>groonga + Perl</h4>
-      <p><a href="https://github.com/yappo/p5-Groonga">p5-Groonga</a>はgroongaのPerlバインディングです。Perlからgroongaをライブラリとして利用することができます。</p>
+      <h4>Groonga + Perl</h4>
+      <p><a href="https://github.com/yappo/p5-Groonga">p5-Groonga</a>はGroongaのPerlバインディングです。PerlからGroongaをライブラリとして利用することができます。</p>
       <p>紹介記事: <a href="http://blog.yappo.jp/yappo/archives/000729.html">YappoLogs: Groonga for Perl Project</a></p>
     </section>
     <section id="ploonga">
-      <h4>groonga + Perl</h4>
-      <p><a href="https://github.com/charsbar/groonga-api">Ploonga</a>はgroongaのPerlバインディングです。Perlからgroongaをライブラリとして利用することができます。</p>
+      <h4>Groonga + Perl</h4>
+      <p><a href="https://github.com/charsbar/groonga-api">Ploonga</a>はGroongaのPerlバインディングです。PerlからGroongaをライブラリとして利用することができます。</p>
       <p>紹介記事: <a href="http://d.hatena.ne.jp/charsbar/20130131/1359567580">Ploonga/Groonga::APIというのを書き始めている件 - Charsbar::Note</a></p>
     </section>
   </section>
 
   <section id="libraries">
     <h3>サーバー向けライブラリ</h3>
-    <p>groongaをサーバー用途で使う場合に便利なAPIやHTTP機能 (リバースプロキシ) を提供するライブラリがあります。</p>
+    <p>Groongaをサーバー用途で使う場合に便利なAPIやHTTP機能 (リバースプロキシ) を提供するライブラリがあります。</p>
     <figure>
       <img src="/images/groonga-related-projects-libraries.png" alt="Node.js is an official trademark of Joyent. 
                                                                      This image is not formally related to or endorsed by the official Joyent Node.js open source or commercial project." />
     </figure>
-    <p>図のgqtpは'groonga query transfer protocol'というgroonga専用プロトコルを意味します。</p>
+    <p>図のgqtpは'groonga query transfer protocol'というGroonga専用プロトコルを意味します。</p>
     <section id="anyevent-groonga">
       <h4>AnyEvent-Groonga</h4>
-      <p><a href="http://search.cpan.org/~miki/AnyEvent-Groonga/">AnyEvent-Groonga</a>は非同期でgroongaサーバへアクセスすることで並列処理を行い、より高いパフォーマンスを引き出すPerl用のgroongaクライアントライブラリです。</p>
+      <p><a href="http://search.cpan.org/~miki/AnyEvent-Groonga/">AnyEvent-Groonga</a>は非同期でGroongaサーバへアクセスすることで並列処理を行い、より高いパフォーマンスを引き出すPerl用のGroongaクライアントライブラリです。</p>
       <p>紹介記事: <a href="http://d.hatena.ne.jp/download_takeshi/20110301/1298911843">非同期で全文検索エンジンgroongaを叩く AnyEvent::Groonga 書いたよ - ダウンロードたけし（寅年）の日記</a></p>
     </section>
     <section id="p5-app-groonga-wrapper">
       <h4>App-Groonga-Wrapper</h4>
-      <p><a href="https://github.com/hideo55/p5-App-Groonga-Wrapper">App::Groonga::Wrapper</a>はローカルのHTTPインターフェイスで動くgroongaサーバのリバースプロキシです。認証や機能の制限、接続元の制限などセキュリティ機構をgroongaサーバに追加します。Perlで書かれています。</p>
+      <p><a href="https://github.com/hideo55/p5-App-Groonga-Wrapper">App::Groonga::Wrapper</a>はローカルのHTTPインターフェイスで動くGroongaサーバのリバースプロキシです。認証や機能の制限、接続元の制限などセキュリティ機構をGroongaサーバに追加します。Perlで書かれています。</p>
       <p>紹介記事: <a href="http://d.hatena.ne.jp/hide_o_55/20110626/1309097120">Hachioji.pm #6に行ってきた - WebService::Blog->new( user => ’hide_o_55’ )</a></p>
     </section>
     <section id="node-groonga">
-      <h4>groonga + Node.js （クライアント）</h4>
-      <p><a href="https://github.com/hideo55/node-groonga">node-groonga</a>はNode.jsから簡単にgroongaサーバーを利用するためのクライアントライブラリです。node-groongaはgroongaをサーバーとして使うので、全文検索はNode.jsプロセスではなくgroongaサーバープロセスが行います。</p>
+      <h4>Groonga + Node.js （クライアント）</h4>
+      <p><a href="https://github.com/hideo55/node-groonga">node-groonga</a>はNode.jsから簡単にGroongaサーバーを利用するためのクライアントライブラリです。node-groongaはGroongaをサーバーとして使うので、全文検索はNode.jsプロセスではなくGroongaサーバープロセスが行います。</p>
       <p>紹介記事: <a href="http://d.hatena.ne.jp/hide_o_55/20110530/1306760694">node-groonga - Node.jsでgroongaにアクセスする - WebService::Blog->new( user => ’hide_o_55’ )</a></p>
     </section>
     <section id="eroonga">
@@ -96,12 +96,12 @@ title: 関連プロジェクト
     </figure>
     <section id="grnwrap">
       <h4>grnwrap</h4>
-      <p><a href="https://github.com/michisu/grnwrap">grnwrap</a>はgroongaのコマンドラインインターフェイスを改良するユーティリティです。</p>
+      <p><a href="https://github.com/michisu/grnwrap">grnwrap</a>はGroongaのコマンドラインインターフェイスを改良するユーティリティです。</p>
       <p>紹介記事: <a href="http://d.hatena.ne.jp/michisu/20110416/p1">Groongaの対話モードをラップするgrnwrap - from __future__ import nowhere @ はてな</a></p>
     </section>
     <section id="zsh-completions">
       <h4>Zshの補完関数</h4>
-      <p><a href="https://github.com/hhatto/zsh_completions/">zsh_completions</a>はhhatoさんの書かれたZshの補完関数集ですが、その中にgroongaとgroonga-suggest-httpd、groonga-suggest-learnerの補完関数も含まれています。</p>
+      <p><a href="https://github.com/hhatto/zsh_completions/">zsh_completions</a>はhhatoさんの書かれたZshの補完関数集ですが、その中にGroongaとgroonga-suggest-httpd、groonga-suggest-learnerの補完関数も含まれています。</p>
       <p>紹介記事: <a href="http://www.hexacosa.net/blog/detail/125/">groongaのZsh補完関数を書きました | hexacosa.net</a></p>
     </section>
   </section>


### PR DESCRIPTION
Currently, it is NOT use **Groonga** notation in introductory article's title.

Because, if it use Groonga notation, it becomes inaccurate....
