### PR TITLE
Add Rust HTTP client project

### DIFF
--- a/ja/related-projects.html
+++ b/ja/related-projects.html
@@ -135,6 +135,10 @@ title: 関連プロジェクト
       <h4>Groonga + Scala</h4>
       <p><a href="https://github.com/naokia/groonga4s">groonga4s</a>はScalaからGroongaサーバーと接続するためのクライアントライブラリです。HTTPに対応しています。</p>
     </section>
+    <section id="ruroonga-client">
+      <h4>Groonga + Rust</h4>
+      <p><a href="https://github.com/cosmo0920/ruroonga_client">ruroonga_client</a>はRustで実装されたGroongaサーバーと接続するためのクライアントライブラリです。HTTPに対応しています。</p>
+    </section>
   </section>
 
   <section id="server-utilities">

--- a/related-projects.html
+++ b/related-projects.html
@@ -125,6 +125,10 @@ title: Related Projects
       <h4>Groonga + Scala</h4>
       <p><a href="https://github.com/naokia/groonga4s">groonga4s</a> is a client library of Groonga server in Scala. It supports HTTP.</p>
     </section>
+    <section id="ruroonga-client">
+      <h4>Groonga + Rust</h4>
+      <p><a href="https://github.com/cosmo0920/ruroonga_client">ruroonga_client</a> is a client library of Groonga server implemented with Rust. It supports HTTP.</p>
+    </section>
   </section>
 
   <section id="server-utilities">


### PR DESCRIPTION
Add `ruroonga_client` descriptions.
It would be nice to announce we start to invesigate Rust language.
Because we help folks who want to use Mozilla's software and Rust language had been shipped from Mozilla! 
