### PR TITLE
Make more natural English

### DIFF
--- a/en/_posts/2016-02-29-grafana-datasource-plugin-groonga.md
+++ b/en/_posts/2016-02-29-grafana-datasource-plugin-groonga.md
@@ -6,37 +6,37 @@ description: grafana-datasource-plugin-groonga 0.1.0 has been released!
 
 ## grafana-datasource-plugin-groonga 0.1.0 has been released
 
-[grafana-datasource-plugin-groonga](https://github.com/groonga/grafana-datasource-plugin-groonga) 0.1.0 released. It's the first version of grafana-datasource-plugin-groonga.
+We glad to announce [grafana-datasource-plugin-groonga](https://github.com/groonga/grafana-datasource-plugin-groonga) 0.1.0 release. It's the first release of grafana-datasource-plugin-groonga.
 
-grafana-datasource-plugin-groonga is a plugin for [Grafana](http://grafana.org/) that adds a datasource for Groonga. It can visualize data of Groonga.
+grafana-datasource-plugin-groonga is a plugin for [Grafana](http://grafana.org/) that adds a datasource for Groonga. It makes to be able to visualize data of Groonga easily.
 
-### Feature
+### Features
 
-* Visualize numeric column data of a table that is included Time type column.
+* Visualize numeric column data of a table that contains Time type column.
   * Access Groonga via HTTP.
-  * Require Time type column because show data as time series.
-  * Excepting numeric type columns are excluded because they are not statistics.
+  * Require Time type column in data because this plugin shows data in time series.
+  * Except for numeric type columns are not covered because they are not statistical information.
 
-Now, it has only the above features. For example, you can visualize specific column data transition in a table includes logs of every fixed time.
+Now, this plugin has only the above features. For example, you can visualize specific column data transition in a table that contains logs of every fixed time.
 
-### Future
+### Plan for the Future
 
 * Visualize multiple columns in a graph.
 * Graph results of drilldown.
 
-The above will be supported in future release.
+The above features will be supported in a future release.
 
 ### Installation
 
-Copy a Git repository or archive of grafana-datasource-plugin-groonga to plugins directory in Grafana. Then, restart Grafana server. See [README](https://github.com/groonga/grafana-datasource-plugin-groonga#installation) for details.
+Copy a Git repository or archive of grafana-datasource-plugin-groonga into plugins directory in Grafana. Then, restart Grafana server. See [README](https://github.com/groonga/grafana-datasource-plugin-groonga#installation) in more details.
 
 ### Usage
 
-First, add datasource as the following screen shot in administration view of Grafana. The following is in a case of to specify a Groonga server running on `http://localhost:10041`.
+First, add this datasource like the following screenshot in administration view of Grafana. The following case specifies a Groonga server running on `http://localhost:10041`.
 
 ![grafana-datasource-plugin-groonga-edit-datasource](https://cloud.githubusercontent.com/assets/386687/13377966/27033252-de36-11e5-91a5-14597b34a2c5.png)
 
-Next, add graph on dashboard, and configure metrics as the following screen shot. It's an example that graph a numeric value column of Data table that has Time type column.
+Next, add graph on dashboard, and configure metrics like the following screenshot. It's an example for the graph which contains a numeric value column of Data table that has Time type column.
 
 ![grafana-plugin-datasource-groonga-screenshot](https://cloud.githubusercontent.com/assets/386687/13373741/41058f8e-ddb3-11e5-83fd-d904f810f8fe.png)
 
@@ -44,10 +44,10 @@ See [README](https://github.com/groonga/grafana-datasource-plugin-groonga#usage)
 
 ### Feedback
 
-We welcome feedback via [Groonga-talk mailing list](https://lists.sourceforge.net/lists/listinfo/groonga-talk) or [GitHub Issues](https://github.com/groonga/grafana-datasource-plugin-groonga/issues).
+We welcome your feedback via [Groonga-talk mailing list](https://lists.sourceforge.net/lists/listinfo/groonga-talk) or [GitHub Issues](https://github.com/groonga/grafana-datasource-plugin-groonga/issues). Feel free to report your feedback.
 
 ### Summary
 
-Introduced the first release of [grafana-datasource-plugin-groonga](https://github.com/groonga/grafana-datasource-plugin-groonga).
+We announced that the first version of [grafana-datasource-plugin-groonga](https://github.com/groonga/grafana-datasource-plugin-groonga) has been released.
 
-Let's visualize Groonga!
+Let's visualize Groonga's data with the new Grafina data source!


### PR DESCRIPTION
- Use we glad to ~ for the annouce opening sentence
- can visualize -> makes to be able to visualize
- Use plural form for 'Feature'
- is included -> contains
  - Because in English, An inianimate object can become subject of a sentence.
- Add missing subjects
  - e.g. 'this plugin'
- Excepting ~ excluding -> Except for ~ not covered
- Add missing relative pronouns
  - e.g. table 'that' contains logs of every fixed time
- More concrete section name
  - Future -> Plan for the Future
- for details -> in more details
- Add missing _who_ do
  - e.g. 'We welcome feedback' is missing who do feedback into us.
  - 'We welcome _your_ feedback' is a perfect sentence. Oh, close! =)
- Add missing who doing
  - e.g. Introduced the first ... -> We announced that the first ...
- More concrete sentence
  - Let's visualize Groonga -> Let's visualize Groonga's data with the new Grafina data source

Follows up this commit: https://github.com/groonga/groonga.org/commit/dc4cdca64e0ce2014e5daa1dee9169f7bdc46bc7
