### PR TITLE
Fix typo about `match_columns parameter` in ja tutorial

### DIFF
--- a/ja/docs/tutorial/match_columns.html
+++ b/ja/docs/tutorial/match_columns.html
@@ -895,7 +895,7 @@ document.write(`
 <span class="c1"># ]</span>
 </pre></div>
 </div>
-<p>この例では、 <code class="docutils literal notranslate"><span class="pre">Terms.entries_whole</span></code> をインデックスとして、 <code class="docutils literal notranslate"><span class="pre">body</span></code> カラムを対象に&quot;Groonga&quot;を検索します。</p>
+<p>この例では、 <code class="docutils literal notranslate"><span class="pre">Terms.entries_body</span></code> をインデックスとして、 <code class="docutils literal notranslate"><span class="pre">body</span></code> カラムを対象に&quot;Groonga&quot;を検索します。</p>
 <p>複数カラムにまたがるインデックスは、インデックスカラムの後にデータカラム名を指定することができます。これは、どのインデックスを使ってどのデータカラムを検索するかを明示しています。</p>
 <p>例えば、 <code class="docutils literal notranslate"><span class="pre">entries_whole</span></code> インデックスが付いた <code class="docutils literal notranslate"><span class="pre">title</span></code> または <code class="docutils literal notranslate"><span class="pre">body</span></code> を検索する場合、 <code class="docutils literal notranslate"><span class="pre">Terms.entries_whole.title</span></code> または <code class="docutils literal notranslate"><span class="pre">Terms.entries_whole.body</span></code> を指定します。 <code class="docutils literal notranslate"><span class="pre">Terms.entries_whole</span></code> をインデックスとして使い、 <code class="docutils literal notranslate"><span class="pre">title</span></code> カラムまたは、 <code class="docutils literal notranslate"><span class="pre">body</span></code> カラムを対象に検索します。</p>
 <p>実行例:</p>


### PR DESCRIPTION
## What I did
- Fixed typo because there is differences between the sample code and the explanation