### PR TITLE
release blog: add a new task for generating blog posts

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,21 @@
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+# Copyright (C) 2024  Horimoto Yasuhiro <horimoto@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+require_relative "release_task"
+
+release_task = ReleaseTask.new("groonga")
+release_task.define

--- a/_config.yml
+++ b/_config.yml
@@ -11,6 +11,10 @@ include:
   - "_images"
   - "_static"
 
+exclude:
+  - "Rakefile"
+  - "release_task.rb"
+
 kramdown:
   input: GFM
   smart_quotes: ["apos", "apos", "quot", "quot"]

--- a/release_task.rb
+++ b/release_task.rb
@@ -1,0 +1,41 @@
+# Copyright (C) 2024  Kodama Takuya <otegami@clear-code.com>
+# Copyright (C) 2024  Horimoto Yasuhiro <horimoto@clear-code.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+class ReleaseTask
+  include Rake::DSL
+
+  def initialize(package)
+    @package = package
+  end
+
+  def define
+    define_generate_blog_task
+  end
+
+  private
+
+  def define_generate_blog_task
+    namespace :release do
+      namespace :blog do
+        desc "Generate release announce posts from a release note"
+        task :generate do
+          puts "TODO: Generate release announce posts for #{@package}"
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
In this PR, we prepare a Rake task for generating release announces in blog.

At the following PRs, we will implement the logic and contents step by step.

### The Rake task is registered.

```console
$ rake -T | grep announce
rake release:blog:generate    # Generate release announce posts from a release note
```

### Call this rake task

```console
rake release:blog:generate
TODO: Generate release announce posts for Groonga
```