### PR TITLE
release blog: generate release post without content

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,8 +15,6 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-require "yaml"
-require "date"
 require_relative "release_task"
 
 release_task = ReleaseTask.new("Groonga", __dir__)

--- a/Rakefile
+++ b/Rakefile
@@ -17,5 +17,11 @@
 
 require_relative "release_task"
 
-release_task = ReleaseTask.new("groonga")
+def env_var(name, default=nil)
+  value = ENV[name] || default
+  raise "${#{name}} is missing" if value.nil?
+  value
+end
+
+release_task = ReleaseTask.new("groonga", env_var("VERSION"), __dir__)
 release_task.define

--- a/Rakefile
+++ b/Rakefile
@@ -21,5 +21,5 @@ def version
   File.read(File.join(__dir__, "_config.yml"))[/^groonga_version: (.+)$/, 1]
 end
 
-release_task = ReleaseTask.new("groonga", version, __dir__)
+release_task = ReleaseTask.new("Groonga", version, __dir__)
 release_task.define

--- a/Rakefile
+++ b/Rakefile
@@ -17,11 +17,9 @@
 
 require_relative "release_task"
 
-def env_var(name, default=nil)
-  value = ENV[name] || default
-  raise "${#{name}} is missing" if value.nil?
-  value
+def version
+  File.read(File.join(__dir__, "_config.yml"))[/^groonga_version: (.+)$/, 1]
 end
 
-release_task = ReleaseTask.new("groonga", env_var("VERSION"), __dir__)
+release_task = ReleaseTask.new("groonga", version, __dir__)
 release_task.define

--- a/Rakefile
+++ b/Rakefile
@@ -15,11 +15,9 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+require "yaml"
+require "date"
 require_relative "release_task"
 
-def version
-  File.read(File.join(__dir__, "_config.yml"))[/^groonga_version: (.+)$/, 1]
-end
-
-release_task = ReleaseTask.new("Groonga", version, __dir__)
+release_task = ReleaseTask.new("Groonga", __dir__)
 release_task.define

--- a/release_task.rb
+++ b/release_task.rb
@@ -42,7 +42,7 @@ class ReleaseTask
   end
 
   def post_filename
-    "#{Time.now.strftime("%F")}-#{@package}-#{@version}.md"
+    "#{Time.now.strftime("%F")}-#{@package.downcase}-#{@version}.md"
   end
 
   def post_content(locale)

--- a/release_task.rb
+++ b/release_task.rb
@@ -36,7 +36,7 @@ class ReleaseTask
   private
 
   def load_jekyll_config
-    YAML.safe_load_file("_config.yml", permitted_classes: [Date])
+    YAML.safe_load_file(File.join(@jekyll_path, "_config.yml"), permitted_classes: [Date])
   end
 
   def detect_version

--- a/release_task.rb
+++ b/release_task.rb
@@ -24,6 +24,7 @@ class ReleaseTask
   def initialize(package, jekyll_path)
     @package = package
     @jekyll_path = jekyll_path
+    @jekyll_config = load_jekyll_config
     @version = detect_version
     @release_date = detect_release_date
   end
@@ -34,16 +35,16 @@ class ReleaseTask
 
   private
 
-  def jekyll_config
+  def load_jekyll_config
     YAML.safe_load_file("_config.yml", permitted_classes: [Date])
   end
 
   def detect_version
-    jekyll_config["#{@package.downcase}_version"]
+    @jekyll_config["#{@package.downcase}_version"]
   end
 
   def detect_release_date
-    jekyll_config["#{@package.downcase}_release_date"]
+    @jekyll_config["#{@package.downcase}_release_date"]
   end
 
   def define_generate_blog_task

--- a/release_task.rb
+++ b/release_task.rb
@@ -18,8 +18,10 @@
 class ReleaseTask
   include Rake::DSL
 
-  def initialize(package)
+  def initialize(package, version, jekyll_path)
     @package = package
+    @version = version
+    @jekyll_path = jekyll_path
   end
 
   def define
@@ -33,8 +35,26 @@ class ReleaseTask
       namespace :blog do
         desc "Generate release announce posts from a release note"
         task :generate do
-          puts "TODO: Generate release announce posts for #{@package}"
+          generate_blog_posts
         end
+      end
+    end
+  end
+
+  def post_filename
+    "#{Time.now.strftime("%F")}-#{@package}-#{@version}.md"
+  end
+
+  def post_content(locale)
+    # TODO: We will write blog post contents here.
+    # After writing contents, we will remove this TODO comment.
+    "#{locale}, #{@package}, #{@version}"
+  end
+
+  def generate_blog_posts
+    ["ja", "en"].each do |locale|
+      File.open("#{@jekyll_path}/#{locale}/_posts/#{post_filename}", "w") do |post|
+        post.write(post_content(locale))
       end
     end
   end

--- a/release_task.rb
+++ b/release_task.rb
@@ -23,6 +23,7 @@ class ReleaseTask
 
   def initialize(product, jekyll_path)
     @product = product
+    @product_id = product.downcase
     @jekyll_path = jekyll_path
     @jekyll_config = load_jekyll_config
     @version = detect_version
@@ -35,20 +36,16 @@ class ReleaseTask
 
   private
 
-  def product_id
-    @product.downcase
-  end
-
   def load_jekyll_config
     YAML.safe_load_file(File.join(@jekyll_path, "_config.yml"), permitted_classes: [Date])
   end
 
   def detect_version
-    @jekyll_config["#{product_id}_version"]
+    @jekyll_config["#{@product_id}_version"]
   end
 
   def detect_release_date
-    @jekyll_config["#{product_id}_release_date"]
+    @jekyll_config["#{@product_id}_release_date"]
   end
 
   def define_generate_blog_task
@@ -63,7 +60,7 @@ class ReleaseTask
   end
 
   def post_filename
-    "#{@release_date.strftime("%F")}-#{product_id}-#{@version}.md"
+    "#{@release_date.strftime("%F")}-#{@product_id}-#{@version}.md"
   end
 
   def post_content(locale)

--- a/release_task.rb
+++ b/release_task.rb
@@ -23,8 +23,9 @@ class ReleaseTask
 
   def initialize(package, jekyll_path)
     @package = package
-    @version = detect_version
     @jekyll_path = jekyll_path
+    @version = detect_version
+    @release_date = detect_release_date
   end
 
   def define
@@ -41,6 +42,10 @@ class ReleaseTask
     jekyll_config["#{@package.downcase}_version"]
   end
 
+  def detect_release_date
+    jekyll_config["#{@package.downcase}_release_date"]
+  end
+
   def define_generate_blog_task
     namespace :release do
       namespace :blog do
@@ -53,7 +58,7 @@ class ReleaseTask
   end
 
   def post_filename
-    "#{Time.now.strftime("%F")}-#{@package.downcase}-#{@version}.md"
+    "#{@release_date.strftime("%F")}-#{@package.downcase}-#{@version}.md"
   end
 
   def post_content(locale)

--- a/release_task.rb
+++ b/release_task.rb
@@ -15,8 +15,8 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
-require "yaml"
 require "date"
+require "yaml"
 
 class ReleaseTask
   include Rake::DSL

--- a/release_task.rb
+++ b/release_task.rb
@@ -15,12 +15,15 @@
 # License along with this library; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 
+require "yaml"
+require "date"
+
 class ReleaseTask
   include Rake::DSL
 
-  def initialize(package, version, jekyll_path)
+  def initialize(package, jekyll_path)
     @package = package
-    @version = version
+    @version = detect_version
     @jekyll_path = jekyll_path
   end
 
@@ -29,6 +32,14 @@ class ReleaseTask
   end
 
   private
+
+  def jekyll_config
+    YAML.safe_load_file("_config.yml", permitted_classes: [Date])
+  end
+
+  def detect_version
+    jekyll_config["#{@package.downcase}_version"]
+  end
 
   def define_generate_blog_task
     namespace :release do

--- a/release_task.rb
+++ b/release_task.rb
@@ -21,8 +21,8 @@ require "yaml"
 class ReleaseTask
   include Rake::DSL
 
-  def initialize(package, jekyll_path)
-    @package = package
+  def initialize(product, jekyll_path)
+    @product = product
     @jekyll_path = jekyll_path
     @jekyll_config = load_jekyll_config
     @version = detect_version
@@ -35,16 +35,20 @@ class ReleaseTask
 
   private
 
+  def product_id
+    @product.downcase
+  end
+
   def load_jekyll_config
     YAML.safe_load_file(File.join(@jekyll_path, "_config.yml"), permitted_classes: [Date])
   end
 
   def detect_version
-    @jekyll_config["#{@package.downcase}_version"]
+    @jekyll_config["#{product_id}_version"]
   end
 
   def detect_release_date
-    @jekyll_config["#{@package.downcase}_release_date"]
+    @jekyll_config["#{product_id}_release_date"]
   end
 
   def define_generate_blog_task
@@ -59,13 +63,13 @@ class ReleaseTask
   end
 
   def post_filename
-    "#{@release_date.strftime("%F")}-#{@package.downcase}-#{@version}.md"
+    "#{@release_date.strftime("%F")}-#{product_id}-#{@version}.md"
   end
 
   def post_content(locale)
     # TODO: We will write blog post contents here.
     # After writing contents, we will remove this TODO comment.
-    "#{locale}, #{@package}, #{@version}"
+    "#{locale}, #{@product}, #{@version}"
   end
 
   def generate_blog_posts


### PR DESCRIPTION
GitHub: GH-83

In this PR, we implement a Rake task for generating release announces in blog without contents.
At the following PRs, we will implement contents step by step.

## Generate release posts

```console
$ rake release:blog:generate
$ tree . | grep 2024-12-04-groonga-14.1.0.md
  │      └── 2024-12-04-groonga-14.1.0.md
  │   │  └── 2024-12-04-groonga-14.1.0.md
```