### PR TITLE
release blog: generate release post contents

### DIFF
--- a/release_task.rb
+++ b/release_task.rb
@@ -63,10 +63,56 @@ class ReleaseTask
     "#{@release_date.strftime("%F")}-#{@product_id}-#{@version}.md"
   end
 
+  def release_note_url
+    major_version = @version.split(".")[0];
+    "/docs/news/#{major_version}.html#release-#{@version.gsub(".", "-")}"
+  end
+
+  def post_ja_content
+    <<-CONTENT
+---
+layout: post.ja
+title: #{@product} #{@version}リリース
+description: #{@product} #{@version}をリリースしました！
+---
+
+## #{@product} #{@version}リリース
+
+#{@product} #{@version}をリリースしました！
+
+それぞれの環境毎のインストール方法は、[インストール](/ja/docs/install.html)をご確認ください。
+
+主な変更点のついては、[リリースノート](/ja#{release_note_url})をご確認ください。
+    CONTENT
+  end
+
+  def post_en_content
+    <<-CONTENT
+---
+layout: post.en
+title: #{@product} #{@version} has been released
+description: #{@product} #{@version} has been released!
+---
+
+## #{@product} #{@version} has been released
+
+#{@product} #{@version} has been released!
+
+For installation instructions on your environments, please see the [Installation Guide](/docs/install.html).
+
+For the information on the changes, please see the [Release Note](#{release_note_url}).
+    CONTENT
+  end
+
   def post_content(locale)
-    # TODO: We will write blog post contents here.
-    # After writing contents, we will remove this TODO comment.
-    "#{locale}, #{@product}, #{@version}"
+    case locale
+    when "ja"
+      post_ja_content
+    when "en"
+      post_en_content
+    else
+      raise "#{locale} isn't supported for release announce posts in blog."
+    end
   end
 
   def generate_blog_posts

--- a/release_task.rb
+++ b/release_task.rb
@@ -86,7 +86,7 @@ description: #{@product} #{@version}をリリースしました！
 
 それぞれの環境毎のインストール方法は、[インストール](/ja#{product_install_url})をご確認ください。
 
-主な変更点のついては、[リリースノート](/ja#{product_release_note_url})をご確認ください。
+主な変更点は、[リリースノート](/ja#{product_release_note_url})をご確認ください。
     CONTENT
   end
 
@@ -104,7 +104,7 @@ description: #{@product} #{@version} has been released!
 
 For installation instructions on your environments, please see the [Installation Guide](#{product_install_url}).
 
-For the information on the changes, please see the [Release Note](#{product_release_note_url}).
+For the information on the changes in this release, please see the [Release Note](#{product_release_note_url}).
     CONTENT
   end
 

--- a/release_task.rb
+++ b/release_task.rb
@@ -72,7 +72,7 @@ class ReleaseTask
     "/docs/news/#{major_version}.html#release-#{@version.gsub(".", "-")}"
   end
 
-  def post_ja_content
+  def post_content_ja
     <<-CONTENT
 ---
 layout: post.ja
@@ -90,7 +90,7 @@ description: #{@product} #{@version}をリリースしました！
     CONTENT
   end
 
-  def post_en_content
+  def post_content_en
     <<-CONTENT
 ---
 layout: post.en
@@ -108,21 +108,10 @@ For the information on the changes in this release, please see the [Release Note
     CONTENT
   end
 
-  def post_content(locale)
-    case locale
-    when "ja"
-      post_ja_content
-    when "en"
-      post_en_content
-    else
-      raise "#{locale} isn't supported for release announce posts in blog."
-    end
-  end
-
   def generate_blog_posts
     ["ja", "en"].each do |locale|
       File.open("#{@jekyll_path}/#{locale}/_posts/#{post_filename}", "w") do |post|
-        post.write(post_content(locale))
+        post.write(__send__("post_content_#{locale}"))
       end
     end
   end

--- a/release_task.rb
+++ b/release_task.rb
@@ -68,7 +68,7 @@ class ReleaseTask
   end
 
   def product_release_note_url
-    major_version = @version.split(".")[0];
+    major_version = @version.split(".")[0]
     "/docs/news/#{major_version}.html#release-#{@version.gsub(".", "-")}"
   end
 

--- a/release_task.rb
+++ b/release_task.rb
@@ -63,6 +63,10 @@ class ReleaseTask
     "#{@release_date.strftime("%F")}-#{@product_id}-#{@version}.md"
   end
 
+  def product_install_url
+    "/docs/install.html"
+  end
+
   def release_note_url
     major_version = @version.split(".")[0];
     "/docs/news/#{major_version}.html#release-#{@version.gsub(".", "-")}"
@@ -80,7 +84,7 @@ description: #{@product} #{@version}をリリースしました！
 
 #{@product} #{@version}をリリースしました！
 
-それぞれの環境毎のインストール方法は、[インストール](/ja/docs/install.html)をご確認ください。
+それぞれの環境毎のインストール方法は、[インストール](/ja#{product_install_url})をご確認ください。
 
 主な変更点のついては、[リリースノート](/ja#{release_note_url})をご確認ください。
     CONTENT
@@ -98,7 +102,7 @@ description: #{@product} #{@version} has been released!
 
 #{@product} #{@version} has been released!
 
-For installation instructions on your environments, please see the [Installation Guide](/docs/install.html).
+For installation instructions on your environments, please see the [Installation Guide](#{product_install_url}).
 
 For the information on the changes, please see the [Release Note](#{release_note_url}).
     CONTENT

--- a/release_task.rb
+++ b/release_task.rb
@@ -67,7 +67,7 @@ class ReleaseTask
     "/docs/install.html"
   end
 
-  def release_note_url
+  def product_release_note_url
     major_version = @version.split(".")[0];
     "/docs/news/#{major_version}.html#release-#{@version.gsub(".", "-")}"
   end
@@ -86,7 +86,7 @@ description: #{@product} #{@version}をリリースしました！
 
 それぞれの環境毎のインストール方法は、[インストール](/ja#{product_install_url})をご確認ください。
 
-主な変更点のついては、[リリースノート](/ja#{release_note_url})をご確認ください。
+主な変更点のついては、[リリースノート](/ja#{product_release_note_url})をご確認ください。
     CONTENT
   end
 
@@ -104,7 +104,7 @@ description: #{@product} #{@version} has been released!
 
 For installation instructions on your environments, please see the [Installation Guide](#{product_install_url}).
 
-For the information on the changes, please see the [Release Note](#{release_note_url}).
+For the information on the changes, please see the [Release Note](#{product_release_note_url}).
     CONTENT
   end
 


### PR DESCRIPTION
GitHub: GH-83

In this PR, we implement a Rake task for generating release announce posts with contents in blog.

## Generate release announce posts

```console
$ rake release:blog:generate
$ tree . | grep 2024-11-05-groonga-14.1.0.md
  │       └── 2024-11-05-groonga-14.1.0.md
  │   │   └── 2024-11-05-groonga-14.1.0.md
```

```console
$ cat en/_posts/2024-11-15-groonga-14.1.0.md
---
layout: post.en
title: Groonga 14.1.0 has been released
description: Groonga 14.1.0 has been released!
---

## Groonga 14.1.0 has been released

Groonga 14.1.0 has been released!

For installation instructions on your environments, please see the [Installation Guide](/docs/install.html).

For the information on the changes in this release, please see the [Release Note](/docs/news/14.html#release-14-1-0).

$ cat ja/_posts/2024-11-05-groonga-14.1.0.md
---
layout: post.ja
title: Groonga 14.1.0リリース
description: Groonga 14.1.0をリリースしました！
---

## Groonga 14.1.0リリース

Groonga 14.1.0をリリースしました！

それぞれの環境毎のインストール方法は、[インストール](/ja/docs/install.html)をご確認ください。

主な変更点は、[リリースノート](/ja/docs/news/14.html#release-14-1-0)をご確認ください。
```