### PR TITLE
ci: Add release jobs

### DIFF
--- a/.github/workflows/document.yml
+++ b/.github/workflows/document.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches:
       - gh-pages
-    tags:
-      - '*'
   pull_request:
   schedule:
     - cron: 0 0 * * *

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,26 @@
+name: Release
+
+on:
+  push:
+    tags:
+    - '*'
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Fetch and extract the archive
+        run: |
+          tag_name="${GITHUB_REF_NAME}"
+          archive_name="document-${tag_name:1}"
+          wget --quiet "https://github.com/groonga/groonga/releases/download/${tag_name}/${archive_name}.tar.gz"
+          tar -xzf "${archive_name}.tar.gz"
+          mv "${archive_name}/ja" "${archive_name}/docs" .
+      - name: Update docs
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add ja docs
+          git commit -m "${GITHUB_REF_NAME:1} has been released!!!"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,8 @@ jobs:
       - name: Fetch and extract the archive
         run: |
           tag_name="${GITHUB_REF_NAME}"
-          archive_name="document-${tag_name:1}"
-          wget --quiet "https://github.com/groonga/groonga/releases/download/${tag_name}/${archive_name}.tar.gz"
+          archive_name="document-${tag_name}"
+          wget --quiet "https://github.com/groonga/groonga/releases/download/v${tag_name}/${archive_name}.tar.gz"
           tar -xzf "${archive_name}.tar.gz"
           mv "${archive_name}/ja" "${archive_name}/docs" .
       - name: Update docs
@@ -22,5 +22,5 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add ja docs
-          git commit -m "${GITHUB_REF_NAME:1} has been released!!!"
+          git commit -m "${GITHUB_REF_NAME} has been released!!!"
           git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Fetch and extract the archive
+      # todo: Wait for the archive file to be uploaded to Groonga's release page.
+      - name: Fetch and extract the archive file
         run: |
           tag_name="${GITHUB_REF_NAME}"
           archive_name="document-${tag_name}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,8 +5,8 @@ on:
     tags:
     - '*'
 jobs:
-  release:
-    name: Release
+  documents:
+    name: Documents
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,3 +25,20 @@ jobs:
           git add ja docs
           git commit -m "${GITHUB_REF_NAME} has been released!!!"
           git push
+  blog:
+    name: Blog
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ruby
+      - name: Update blog
+        run: |
+          tag_name="${GITHUB_REF_NAME}"
+          rake release:blog:generate
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "*/_posts/*-groonga-${tag_name}.md"
+          git commit -m "blog: add an article about Groonga ${tag_name}"
+          git push

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,8 +16,8 @@ jobs:
           tag_name="${GITHUB_REF_NAME}"
           archive_name="document-${tag_name}"
           wget --quiet "https://github.com/groonga/groonga/releases/download/v${tag_name}/${archive_name}.tar.gz"
-          tar -xzf "${archive_name}.tar.gz"
-          mv "${archive_name}/ja" "${archive_name}/docs" .
+          rm -rf docs ja/docs
+          tar -xzf "${archive_name}.tar.gz" --strip-components 1
       - name: Update docs
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
Documents:

1. Fetch document archive from Groonga release page
2. Extract tar.gz file
3. Deploy to the repository by git push

Blog:

1. Run `rake release:blog:generate`
2. Deploy to the repository by git push