### PR TITLE
ci: release: Add the token as it is required

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           run_id=$(gh run list \
                      --repo groonga/groonga \
                      --workflow=document.yml \
-                      --limit 1 \
+                     --limit 1 \
                      --json "databaseId,event,headBranch" \
                      --jq ".[] | select(.event == \"push\" and .headBranch == \"v${GITHUB_REF_NAME}\") | .databaseId")
           gh run watch "${run_id}" --repo groonga/groonga --exit-status

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,9 +19,12 @@ jobs:
           run_id=$(gh run list \
                      --repo groonga/groonga \
                      --workflow=document.yml \
+                      --limit 1 \
                      --json "databaseId,event,headBranch" \
                      --jq ".[] | select(.event == \"push\" and .headBranch == \"v${GITHUB_REF_NAME}\") | .databaseId")
           gh run watch "${run_id}" --repo groonga/groonga --exit-status
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update docs
         run: |
           set -x

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,11 @@ jobs:
         run: |
           run_id=$(gh run list \
                      --repo groonga/groonga \
-                     --workflow=document.yml \
-                     --limit 1 \
-                     --json "databaseId,event,headBranch" \
-                     --jq ".[] | select(.event == \"push\" and .headBranch == \"v${GITHUB_REF_NAME}\") | .databaseId")
+                     --workflow document.yml \
+                     --branch "v${GITHUB_REF_NAME}" \
+                     --status success \
+                     --json databaseId \
+                     --jq ".[].databaseId")
           gh run watch "${run_id}" --repo groonga/groonga --exit-status
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
           run_id=$(gh run list \
                      --repo groonga/groonga \
                      --workflow document.yml \
+                     --limit 1 \
                      --branch "v${GITHUB_REF_NAME}" \
                      --status success \
                      --json databaseId \


### PR DESCRIPTION
Added the token to `gh` command because it is required.

Rarely, a tag is pushed multiple times.
We added `--limit 1` to get only the ID of the latest workflow.