### PR TITLE
release: use the latest tag to update version information

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -4,7 +4,7 @@ paginate: 5
 url: https://groonga.org
 future: true
 incremental: true
-groonga_version: 14.1.3
+groonga_version: "14.1.3"
 groonga_release_date: 2025-01-29
 
 include:

--- a/release_task.rb
+++ b/release_task.rb
@@ -162,8 +162,10 @@ For the information on the changes in this release, please see the [Release Note
         release_tag_name = latest_tag["name"]
         # "14.1.3", "14.14" or "3.2.5"
         latest_version = release_tag_name[/\d+(\.\d+){1,2}/, 0]
-        # "2024-12-03"
-        latest_release_date = Date.parse(tag_commit["commit"]["committer"]["date"]).to_s
+        # "2025-01-29T03:03:15Z(UTC)" -> "2025-01-30(JST)"
+        latest_release_date = Time.parse(tag_commit["commit"]["committer"]["date"])
+                                  .getlocal("+09:00")
+                                  .strftime("%Y-%m-%d")
         jekyll_config = File.read(@jekyll_config_path)
         escaped_product_id = Regexp.escape(@product_id)
         jekyll_config.gsub!(/^(#{escaped_product_id}_version: ).+$/) do

--- a/release_task.rb
+++ b/release_task.rb
@@ -27,6 +27,12 @@ class ReleaseTask
       @repository = repository
     end
 
+    def fetch_by(uri)
+      URI(uri).open do |input|
+        JSON.parse(input.read)
+      end
+    end
+
     def latest_release
       api_uri("releases").open do |input|
         JSON.parse(input.read)[0]
@@ -36,12 +42,6 @@ class ReleaseTask
     def latest_tag
       api_uri("tags").open do |input|
         JSON.parse(input.read)[0]
-      end
-    end
-
-    def find_commit_by(commit_sha)
-      api_uri("commits/#{commit_sha}").open do |input|
-        JSON.parse(input.read)
       end
     end
 
@@ -157,7 +157,7 @@ For the information on the changes in this release, please see the [Release Note
       task :update do
         github_client = GitHubClient.new(@product, @product)
         latest_tag = github_client.latest_tag
-        tag_commit = github_client.find_commit_by(latest_tag["commit"]["sha"])
+        tag_commit = github_client.fetch_by(latest_tag["commit"]["url"])
         # "v14.1.3"(Groonga), "v14.14"(Mroonga) or "3.2.5"(PGroonga)
         release_tag_name = latest_tag["name"]
         # "14.1.3", "14.14" or "3.2.5"

--- a/release_task.rb
+++ b/release_task.rb
@@ -39,6 +39,12 @@ class ReleaseTask
       end
     end
 
+    def find_commit_by(commit_sha)
+      api_uri("commits/#{commit_sha}").open do |input|
+        JSON.parse(input.read)
+      end
+    end
+
     private
     def api_uri(path)
       URI("https://api.github.com/repos/#{@user}/#{@repository}/#{path}")
@@ -149,13 +155,15 @@ For the information on the changes in this release, please see the [Release Note
     namespace :version do
       desc "Update version"
       task :update do
-        latest_tag = GitHubClient.new(@product, @product).latest_tag
+        github_client = GitHubClient.new(@product, @product)
+        latest_tag = github_client.latest_tag
+        tag_commit = github_client.find_commit_by(latest_tag["commit"]["sha"])
         # "v14.1.3"(Groonga), "v14.14"(Mroonga) or "3.2.5"(PGroonga)
         release_tag_name = latest_tag["name"]
         # "14.1.3", "14.14" or "3.2.5"
         latest_version = release_tag_name[/\d+(\.\d+){1,2}/, 0]
         # "2024-12-03"
-        latest_release_date = Date.today.to_s
+        latest_release_date = Date.parse(tag_commit["commit"]["committer"]["date"]).to_s
         jekyll_config = File.read(@jekyll_config_path)
         escaped_product_id = Regexp.escape(@product_id)
         jekyll_config.gsub!(/^(#{escaped_product_id}_version: ).+$/) do

--- a/release_task.rb
+++ b/release_task.rb
@@ -33,6 +33,12 @@ class ReleaseTask
       end
     end
 
+    def latest_tag
+      api_uri("tags").open do |input|
+        JSON.parse(input.read)[0]
+      end
+    end
+
     private
     def api_uri(path)
       URI("https://api.github.com/repos/#{@user}/#{@repository}/#{path}")
@@ -143,13 +149,13 @@ For the information on the changes in this release, please see the [Release Note
     namespace :version do
       desc "Update version"
       task :update do
-        latest_release = GitHubClient.new(@product, @product).latest_release
-        # "Groonga 14.1.1 - 2024-12-03" or "Mroonga 14.11 - 2024-12-03"
-        release_name = latest_release["name"]
-        # "14.1.1" or "14.11"
-        latest_version = release_name[/\d+(\.\d+){1,2}/, 0]
+        latest_tag = GitHubClient.new(@product, @product).latest_tag
+        # "v14.1.3"(Groonga), "v14.14"(Mroonga) or "3.2.5"(PGroonga)
+        release_tag_name = latest_tag["name"]
+        # "14.1.3", "14.14" or "3.2.5"
+        latest_version = release_tag_name[/\d+(\.\d+){1,2}/, 0]
         # "2024-12-03"
-        latest_release_date = release_name[/\d+-\d+-\d+/, 0]
+        latest_release_date = Date.today.to_s
         jekyll_config = File.read(@jekyll_config_path)
         escaped_product_id = Regexp.escape(@product_id)
         jekyll_config.gsub!(/^(#{escaped_product_id}_version: ).+$/) do

--- a/release_task.rb
+++ b/release_task.rb
@@ -162,7 +162,7 @@ For the information on the changes in this release, please see the [Release Note
         release_tag_name = latest_tag["name"]
         # "14.1.3", "14.14" or "3.2.5"
         latest_version = release_tag_name[/\d+(\.\d+){1,2}/, 0]
-        # "2025-01-29T03:03:15Z(UTC)" -> "2025-01-30(JST)"
+        # "2025-01-29T15:00:00Z(UTC)" -> "2025-01-30(JST)"
         latest_release_date = Time.parse(tag_commit["commit"]["committer"]["date"])
                                   .getlocal("+09:00")
                                   .strftime("%Y-%m-%d")

--- a/release_task.rb
+++ b/release_task.rb
@@ -27,12 +27,6 @@ class ReleaseTask
       @repository = repository
     end
 
-    def fetch_by(uri)
-      URI(uri).open do |input|
-        JSON.parse(input.read)
-      end
-    end
-
     def latest_release
       api_uri("releases").open do |input|
         JSON.parse(input.read)[0]
@@ -42,6 +36,12 @@ class ReleaseTask
     def latest_tag
       api_uri("tags").open do |input|
         JSON.parse(input.read)[0]
+      end
+    end
+
+    def tag_commit(tag)
+      URI(tag["commit"]["url"]).open do |input|
+        JSON.parse(input.read)
       end
     end
 
@@ -157,7 +157,7 @@ For the information on the changes in this release, please see the [Release Note
       task :update do
         github_client = GitHubClient.new(@product, @product)
         latest_tag = github_client.latest_tag
-        tag_commit = github_client.fetch_by(latest_tag["commit"]["url"])
+        tag_commit = github_client.tag_commit(latest_tag)
         # "v14.1.3"(Groonga), "v14.14"(Mroonga) or "3.2.5"(PGroonga)
         release_tag_name = latest_tag["name"]
         # "14.1.3", "14.14" or "3.2.5"


### PR DESCRIPTION
## Issue

Previously, we needed to wait for the release page creation to complete before running `rake release:version:update`. However, that step was sometimes overlooked, and the task was run before the release page existed. As a result, this task would fail with an error when the release page was unavailable.

## Solution

By switching to the latest tag instead of the latest release, we ensure that the version update process no longer depends on the presence of the release page. As soon as a tag is pushed, we can execute this rake task to retrieve the release version.