### PR TITLE
Use secure URL of related projects

### DIFF
--- a/related-projects.html
+++ b/related-projects.html
@@ -40,7 +40,7 @@ title: Related Projects
     </figure>
     <section id="nroonga">
       <h4>Groonga + Node.js</h4>
-      <p><a href="http://nroonga.github.com/">Nroonga</a> is a Groonga binding for Node.js. Nroonga uses Groonga as a library. It means that fulltext search is done in Node.js process.</p>
+      <p><a href="https://nroonga.github.io/">Nroonga</a> is a Groonga binding for Node.js. Nroonga uses Groonga as a library. It means that fulltext search is done in Node.js process.</p>
     </section>
     <section id="rroonga">
       <h4>Groonga + Ruby</h4>

--- a/related-projects.html
+++ b/related-projects.html
@@ -23,7 +23,7 @@ title: Related Projects
     </figure>
     <section id="mroonga">
       <h4>Groonga + MySQL</h4>
-      <p><a href="http://mroonga.org/">Mroonga</a> is a MySQL storage engine built on Groonga. It adds high performance and high accuracy fulltext search feature to MySQL.</p>
+      <p><a href="https://mroonga.org/">Mroonga</a> is a MySQL storage engine built on Groonga. It adds high performance and high accuracy fulltext search feature to MySQL.</p>
     </section>
     <section id="pgroonga">
       <h4>Groonga + PostgreSQL</h4>
@@ -44,7 +44,7 @@ title: Related Projects
     </section>
     <section id="rroonga">
       <h4>Groonga + Ruby</h4>
-      <p><a href="http://ranguba.org/#about-rroonga">Rroonga</a> is a Ruby bindings for Groonga. Rroonga is a part of <a href="http://ranguba.org/">The Ranguba project</a> which provides a fulltext search system built on Groonga.
+      <p><a href="https://ranguba.org/#about-rroonga">Rroonga</a> is a Ruby bindings for Groonga. Rroonga is a part of <a href="https://ranguba.org/">The Ranguba project</a> which provides a fulltext search system built on Groonga.
     </section>
     <section id="grnmini">
       <h4>Groonga + Ruby</h4>
@@ -82,7 +82,7 @@ title: Related Projects
     <p class="note">The gqtp described in above picture means "groonga query transfer protocol".</p>
     <section id="anyevent-groonga">
       <h4>Groonga + Perl</h4>
-      <p><a href="http://search.cpan.org/~miki/AnyEvent-Groonga/">AnyEvent-Groonga</a> is a high performance Groonga client library for Perl. It accesses Groonga server asynchronously.</p>
+      <p><a href="https://metacpan.org/dist/AnyEvent-Groonga">AnyEvent-Groonga</a> is a high performance Groonga client library for Perl. It accesses Groonga server asynchronously.</p>
     </section>
     <section id="node-groonga">
       <h4>Groonga + Node.js</h4>


### PR DESCRIPTION
Some webpages of related projects are redirected to https: URLs. We should link to the destination sites for better performance with less redirections.

Note: some websites of related projects are actually closed and there are some dead links, so we also should maintain them, but I keep them as-is - it may be done by a separate PR.